### PR TITLE
Clean up configuration and remove unused settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # macOS
 .DS_Store
-Brewfile.lock.json
 
 # deps
 **/node_modules/

--- a/config/agents/AGENTS.md
+++ b/config/agents/AGENTS.md
@@ -43,11 +43,8 @@
 
 - `@` is the working-copy commit; changes auto-amend it. There is no staging
   area.
-- If `@` is a single working-copy commit with multiple parents/bookmark heads,
-  assume the user is likely using a megamerge workflow. Do not push the
-  megamerge. Move the current changes into the intended branch with
-  `jj squash --into <rev> -m "msg"`, or split/rebase a new commit onto the
-  correct branch if the changes do not belong in an existing commit.
+- A multi-parent `@` is a megamerge workspace; never push it. See `/skill:jj`
+  for how to place edits onto the right branch.
 - Always pass `-m "msg"` to `jj commit`, `jj describe`, and `jj squash`.
 - Never use `jj split` in automation; it is interactive.
 - After fetching: `jj git fetch && jj rebase -b @ -o main`.

--- a/config/agents/skills/jj/SKILL.md
+++ b/config/agents/skills/jj/SKILL.md
@@ -61,6 +61,9 @@ description: Complete jj version control reference. Use when you need the full c
 Add these to `~/.jjconfig.toml` or `.jj/config.toml`:
 
 ```toml
+[revset-aliases]
+'closest_bookmark(to)' = 'heads(::to & bookmarks())'
+
 [aliases]
 # Move the closest bookmark to the current commit. Useful when working on a
 # named bookmark, creating commits, and needing to update the bookmark before

--- a/config/git/config
+++ b/config/git/config
@@ -4,7 +4,5 @@
 [user]
 	name = "Shardul Baral"
 	email = "shardul@baral.ca"
-[credential]
-	helper = cache --timeout=3600
 [credential "https://github.com"]
 	helper = !gh auth git-credential

--- a/config/git/ignore
+++ b/config/git/ignore
@@ -1,7 +1,3 @@
 # macOS
 .DS_Store
 .direnv/
-.env
-.venv/
-venv/
-node_modules/

--- a/config/jj/config.toml
+++ b/config/jj/config.toml
@@ -5,6 +5,9 @@ email = "shardul@baral.ca"
 [ui]
 default-command = 'log'
 
+[revset-aliases]
+'closest_bookmark(to)' = 'heads(::to & bookmarks())'
+
 [aliases]
 # Move the closest bookmark to the current commit. Useful when working on a
 # named branch, creating a bunch of commits, and then needing to update the

--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -8,7 +8,6 @@ vim.pack.add({
   "https://github.com/nvim-treesitter/nvim-treesitter",
 })
 
-vim.o.termguicolors = true
 vim.o.wrap = false
 vim.o.scrolloff = 10
 vim.o.tabstop = 2
@@ -16,12 +15,9 @@ vim.o.shiftwidth = 2
 vim.o.expandtab = true
 vim.o.number = true
 vim.o.laststatus = 3
-vim.o.writebackup = false
 vim.o.swapfile = false
 vim.o.autowrite = true
 vim.o.clipboard = "unnamedplus"
-vim.o.smartindent = true
-vim.o.ttimeoutlen = 0
 vim.o.ignorecase = true
 vim.o.grepprg = "rg --hidden --vimgrep --no-heading --smart-case"
 vim.cmd.colorscheme("alabaster")

--- a/config/zed/keymap.json
+++ b/config/zed/keymap.json
@@ -22,7 +22,7 @@
       ", y": "workspace::CopyRelativePath",
       ", f e": [
         "pane::DeploySearch",
-        { "excluded_files": "*.har, *.json, *.spec.ts, inlinedbaml.ts" },
+        { "excluded_files": "*.har, *.json, *.spec.ts" },
       ],
       ", f f": [
         "pane::DeploySearch",

--- a/config/zed/settings.json
+++ b/config/zed/settings.json
@@ -4,11 +4,7 @@
     "light": "Alabaster BG",
     "dark": "Alabaster Dark",
   },
-  "outline_panel": {
-    "dock": "left",
-  },
   "project_panel": {
-    "dock": "left",
     "hide_gitignore": true,
     "hide_root": true,
   },
@@ -33,10 +29,8 @@
   "buffer_font_family": "JetBrainsMono Nerd Font Mono",
   "vim_mode": true,
   "use_system_window_tabs": true,
-  "load_direnv": "direct",
   "languages": {
     "Nix": {
-      "language_servers": ["nil", "!nixds"],
       "formatter": {
         "external": {
           "command": "nixfmt",

--- a/setup
+++ b/setup
@@ -20,7 +20,7 @@ link() {
   ln -snf "$1" "$2"
 }
 
-mkdir -p "$HOME/.config/"{fish,git,jj,jjui,nvim/lua,nvim/colors,ghostty/themes,zed} "$HOME/.pi/agent/extensions" "$HOME/.agents/skills" "$HOME/.codex" "$HOME/bin" "$HOME/.npm-global/bin"
+mkdir -p "$HOME/.config/"{fish,git,jj,jjui,nvim/colors,ghostty/themes,zed} "$HOME/.pi/agent/extensions" "$HOME/.agents/skills" "$HOME/.codex" "$HOME/bin" "$HOME/.npm-global/bin"
 
 link "$DOT/config/fish/config.fish" "$HOME/.config/fish/config.fish"
 link "$DOT/config/git/config" "$HOME/.config/git/config"


### PR DESCRIPTION
This PR removes unused configuration options, simplifies settings across multiple tools, and updates documentation to reflect current workflows.

## Key Changes

- **Jujutsu (jj) documentation**: Simplified megamerge workflow guidance in AGENTS.md and added `closest_bookmark` revset alias to jj config for easier bookmark management
- **Zed editor**: Removed unused `outline_panel` configuration, `load_direnv` setting, and nixds language server configuration; cleaned up search exclusion patterns
- **Neovim**: Removed unused vim options (`termguicolors`, `writebackup`, `smartindent`, `ttimeoutlen`) that were either redundant or not needed
- **Git configuration**: Removed generic credential cache helper in favor of GitHub-specific credential helper
- **Gitignore files**: Removed Python virtual environment patterns (`.env`, `.venv/`, `venv/`) and `node_modules/` from config-level ignore, keeping them only in root `.gitignore`
- **Setup script**: Removed `nvim/lua` directory creation as it's no longer needed
- **Root gitignore**: Removed `Brewfile.lock.json` from tracked ignores

## Implementation Details

The changes maintain functionality while reducing configuration bloat. The jj `closest_bookmark` alias is documented in both the skill reference and the actual config file for consistency. All removals are of genuinely unused settings that were either defaults or no longer applicable to the current development setup.

https://claude.ai/code/session_01TKdHp8dx3HpKXDn46pJqVp